### PR TITLE
Add package dependencies as required by "R CMD check"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lltools
 Type: Package
 Title: Provides Leaflet Helpers for the Inventoryverse
-Version: 2020.12.14
+Version: 2021.04.19
 Author: David Holstius
 Maintainer: David Holstius <dholstius@baaqmd.gov>
 Description: More about what it does (maybe more than one line)
@@ -12,7 +12,14 @@ Depends:
   leaflet.extras
 Imports:
   CARE,
-  leafgl
+  leafgl,
+  colourvalues,
+  dplyr,
+  funtools,
+  leafpop,
+  mapview,
+  purrr,
+  sf
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true
@@ -21,7 +28,8 @@ Roxygen: list(markdown = TRUE)
 Suggests: 
   htmlwidgets,
   htmltools,
-  testthat (>= 2.1.0)
+  testthat (>= 2.1.0),
+  knitr
 Remotes:
   github::BAAQMD/geotools,
   github::BAAQMD/CARE


### PR DESCRIPTION
This is necessary for the reason describe in [Inventory PR #14](https://github.com/BAAQMD/inventory/pull/14#issue-618675841).

In short, we set a goal or reducing / eliminating all the warnings we get when starting an new R Session. In particular, we wanted to focus on reducing warnings when loading the Inventory package. 

A good first step in that is to have the Inventory package pass `R CMD check`. Currently that is blocked by the `lltools` package not having proper depencies listed. This PR fixes that.